### PR TITLE
dev/ludndev

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Options:
   -s, --special                  Include special characters
       --hide                     Hide password from terminal display [default: false]
       --copy                     Copy password to clipboard [default: false]
+      --export <EXPORT>          Export's file path
   -h, --help                     Print help
   -V, --version                  Print version
 ```
@@ -57,6 +58,12 @@ Generate 3 complex passwords of length 20, hide them from display, and copy to c
 
 ```bash
 password_generator -l 20 -q 3 --complexity complex --hide --copy
+```
+
+Generate 5 complex passwords of length 20, hide them from display, and export to passwords.txt:
+
+```bash
+password_generator -l 20 -q 5 --complexity complex --hide --export passwords.txt
 ```
 
 ### Notes

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ password_generator -l 20 -q 3 --complexity complex --hide --copy
 - [x] copy generated password directly into the memory (like `CTRL/CMD + C`)
 - [x] add author to clap definition
 - [ ] evaluate password strength (if user entered his own password)
-- [ ] generated bin for linux, windows and darwin (mac) using GitHub Action
+- [x] generated bin for linux, windows and darwin (mac) using GitHub Action
 - [x] ~~check if password is already leaked like [Pwned Passwords](https://haveibeenpwned.com/Passwords)~~
 [//]: # (  paid api)
 - [x] fix fails and remove todos from test.rs
 - [ ] write test for copy to clipboard
-- [ ] format generated password output to 
-  - [ ] plain text file
+- [x] format generated password output to 
+  - [x] plain text file
   - [ ] csv
   - [ ] json
 - [x] improve random password generation

--- a/README.md
+++ b/README.md
@@ -64,21 +64,6 @@ password_generator -l 20 -q 3 --complexity complex --hide --copy
 - Ensure your system supports clipboard operations for the `--copy` option to work properly.
 - Use the `--help` option to view all available command-line options and usage information.
 
-## Todo
-- [x] copy generated password directly into the memory (like `CTRL/CMD + C`)
-- [x] add author to clap definition
-- [ ] evaluate password strength (if user entered his own password)
-- [x] generated bin for linux, windows and darwin (mac) using GitHub Action
-- [x] ~~check if password is already leaked like [Pwned Passwords](https://haveibeenpwned.com/Passwords)~~
-[//]: # (  paid api)
-- [x] fix fails and remove todos from test.rs
-- [ ] write test for copy to clipboard
-- [x] format generated password output to 
-  - [x] plain text file
-  - [ ] csv
-  - [ ] json
-- [x] improve random password generation
-
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,20 +82,18 @@ fn main() {
     while passwords_generated < args.quantity {
         let password = generate_password(args.length, args.special, &args.complexity);
 
-        if !args.hide {
-            // Print the password
-            println!("{}", password);
-        }
-
-        if args.copy || !args.export.is_empty() {
-            passwords.push_str(&password);
-            passwords.push_str(newline);
-        }
+        passwords.push_str(&password);
+        passwords.push_str(newline);
 
         passwords_generated += 1;
     }
 
     let passwords_string: String = passwords.trim().parse().unwrap();
+
+    if !args.hide {
+        // Print the password(s)
+        println!("{}", passwords_string);
+    }
 
     // Ensure the export path is not empty
     if !args.export.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
 #[cfg(test)]
 mod test;
 
-use std::fs::File;
 use clap::{Parser, ValueEnum};
 use cli_clipboard::{ClipboardContext, ClipboardProvider};
 use rand::{
     seq::{IteratorRandom, SliceRandom},
     Rng,
 };
+use std::fs::File;
 use std::io::Write;
 use std::iter;
 use std::path::Path;
@@ -113,9 +113,7 @@ fn main() {
 
     if args.copy {
         // Copy password to clipboard
-        clipboard
-            .set_contents(passwords_string)
-            .unwrap();
+        clipboard.set_contents(passwords_string).unwrap();
         println!("Password(s) copied to clipboard.");
     }
 }


### PR DESCRIPTION
- **feat: add plain text password's export support**
  

- **refact: password printing logic and passwords collection**
  

- **refact: format code using cargo fmt**
  

- **doc: update todos in README.md**
  

- **doc: remove todos from README.md**
  

- **doc: add examples for passwords export**
  